### PR TITLE
Circular Linked List Remove When One Node

### DIFF
--- a/data_structures/linked_list/circular_linked_list/circular_linked_list_remove.py
+++ b/data_structures/linked_list/circular_linked_list/circular_linked_list_remove.py
@@ -84,6 +84,9 @@ class CircularLinkedList:
         split_cllist.print_list()
 
     def remove(self, key):
+        if self.head.next == self.head and self.head.data == key:
+            self.head = None
+            return
         if self.head.data == key:
             cur = self.head 
             while cur.next != self.head:

--- a/data_structures/linked_list/circular_linked_list/circular_linked_list_remove.py
+++ b/data_structures/linked_list/circular_linked_list/circular_linked_list_remove.py
@@ -84,9 +84,6 @@ class CircularLinkedList:
         split_cllist.print_list()
 
     def remove(self, key):
-        if self.head.next == self.head and self.head.data == key:
-            self.head = None
-            return
         if self.head.data == key:
             cur = self.head 
             while cur.next != self.head:


### PR DESCRIPTION
When using the remove() function on the circular linked list it would not work if there was only one node in the list. This if statement at the beginning fixes this by checking if there is only one node that has the data equal the key. 