### PR TITLE
Sort vector in case where matrix has only one row

### DIFF
--- a/technical_interview/matrix_median.py
+++ b/technical_interview/matrix_median.py
@@ -18,7 +18,7 @@ Median is 5. So, we return 5.
 
 def median_matrix(A):
     if len(A) == 1:
-        vec = A[0]
+        vec = sorted(A[0])
         return vec[len(vec)//2]
     else:
         new_list = []


### PR DESCRIPTION
This addresses the case in which the input matrix has a length of one, but that list is not itself sorted, in which case the version prior to this PR would return the middlemost value by index, but not the median.

e.g, consider the difference between `median_matrix([[1,3,5]])` and `median_matrix([[1,5,3]])`

