### PR TITLE
Made change head of split list

### DIFF
--- a/data_structures/linked_list/circular_linked_list/circular_linked_list_is_circular_linked_list.py
+++ b/data_structures/linked_list/circular_linked_list/circular_linked_list_is_circular_linked_list.py
@@ -97,10 +97,12 @@ class CircularLinkedList:
         prev.next = self.head 
 
         split_cllist = CircularLinkedList()
+        split_list_head = cur
         while cur.next != self.head:
             split_cllist.append(cur.data)
             cur = cur.next
         split_cllist.append(cur.data)
+        cur.next = split_list_head
 
         self.print_list()
         print("\n")


### PR DESCRIPTION
After splitting the list , we have two lists. right  One is 

A
B
C

Second one is 

D
E
F

great

in the first split CLList, lats node "C" pointing to the self.head which is "A" everything is good and correct

but in the second split CLList, the last node "F" is pointing to the head of first CLList which is eventually not correct.

so i have make changes and point the last Node of second CLList "F" to head of own CLList "D"

i hope this make sense